### PR TITLE
Simplify generics.

### DIFF
--- a/Basis/Monoid.swift
+++ b/Basis/Monoid.swift
@@ -32,7 +32,7 @@ public protocol Monoid {
 	class func mappend(M) -> M -> M
 }
 
-public func mconcat<M, S: Monoid where S.M == M>(s: S, t: [M]) -> M {
+public func mconcat<S: Monoid>(s: S, t: [S.M]) -> S.M {
 	return (t.reduce(S.mempty()) { S.mappend($0)($1) })
 }
 


### PR DESCRIPTION
Since `M` can be unambiguously determined via the associated type in `S`, we don’t need parameterize by `M` explicitly.

(I checked this out locally in order to test that it compiled correctly, but all of the protocol conformances had to be removed. Long story short, it _did_ compile, but I’m not pushing all of those other changes because everything will be ruined forever.)
